### PR TITLE
Fix Next.js path alias resolution

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `jsconfig.json` to define `@` alias for Next.js

## Testing
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_684ff755efd4832fa1339b48aa00256f