### PR TITLE
Add extended Tailwind theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,16 @@ module.exports = {
     },
     extend: {
       colors: {
+        coffee: {
+          light: '#d2b48c',
+          DEFAULT: '#9b5524',
+          dark: '#6b3e20',
+        },
+        status: {
+          pending: '#fbbf24',
+          ready: '#34d399',
+          collected: '#60a5fa',
+        },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
@@ -66,12 +76,22 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        fade: {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+        slide: {
+          from: { transform: "translateY(1rem)", opacity: "0" },
+          to: { transform: "translateY(0)", opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        fade: "fade 0.3s ease-in",
+        slide: "slide 0.3s ease-out",
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind colors with coffee brand and order status colors
- add fade/slide animations
- include `@tailwindcss/forms` plugin

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68510b5cf0e8832fa15c40e80453fe1f