### PR TITLE
Fix missing Tailwind plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0",
+    "@tailwindcss/forms": "^0.5.3",
+    "tailwindcss-animate": "^1.0.0",
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-tabs": "^1.0.0"
   },
@@ -29,8 +31,6 @@
     "eslint-config-next": "14.0.0",
     "postcss": "^8",
     "tailwindcss": "^3",
-    "@tailwindcss/forms": "^0.5.3",
-    "tailwindcss-animate": "^1.0.0",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "eslint-config-next": "14.0.0",
     "postcss": "^8",
     "tailwindcss": "^3",
+    "@tailwindcss/forms": "^0.5.3",
+    "tailwindcss-animate": "^1.0.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- install the `@tailwindcss/forms` and `tailwindcss-animate` plugins

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6851129e3208832fb50db976cf2adb75