### PR TITLE
Add basic Jest test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ npm run build
 npm start
 ```
 
+### 5. Run Tests
+
+```bash
+npm test
+```
+
 ## Project Structure
 
 ```

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = {presets: ['next/babel']};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  }
+};

--- a/lib/__tests__/store.test.js
+++ b/lib/__tests__/store.test.js
@@ -1,0 +1,19 @@
+import { addOrder, getOrders, updateOrderStatus, deleteOrder } from '../store';
+
+function clearOrders() {
+  const all = getOrders();
+  all.forEach(o => deleteOrder(o.id));
+}
+
+afterEach(() => {
+  clearOrders();
+});
+
+test('add and update order', () => {
+  const order = addOrder({ item: 'Latte' });
+  expect(getOrders().length).toBe(1);
+  expect(order.status).toBe('pending');
+  const updated = updateOrderStatus(order.id, 'ready');
+  expect(updated.status).toBe('ready');
+});
+

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -1,0 +1,6 @@
+import { cn } from '../utils';
+
+test('cn merges class names', () => {
+  expect(cn('p-2', false && 'hidden')).toBe('p-2');
+  expect(cn('p-2', 'm-1')).toBe('p-2 m-1');
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build && node scripts/optimize-css.js",
     "start": "next start",
     "lint": "next lint",
-    "optimize:css": "tailwindcss -i ./app/globals.css -o ./styles/globals.css --minify"
+    "optimize:css": "tailwindcss -i ./app/globals.css -o ./styles/globals.css --minify",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.0.0",
@@ -29,6 +30,8 @@
     "eslint-config-next": "14.0.0",
     "postcss": "^8",
     "tailwindcss": "^3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add jest and babel-jest to dev dependencies
- configure Jest and Babel
- add simple unit tests for utils and store
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68513aa06378832fbf6bcf345d015a9e